### PR TITLE
Fix PlayerAPI incompatibility

### DIFF
--- a/src/main/java/cuchaz/ships/Collider.java
+++ b/src/main/java/cuchaz/ships/Collider.java
@@ -14,21 +14,49 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 
+import static cuchaz.ships.Collider.PostMoveAction.*;
+
 public class Collider {
-	
-	public static void onEntityMove(Entity entity, double dx, double dy, double dz) {
+
+	private static class EntityMoveInfo {
+		private boolean isInsideEntityMove;
+
+		// save the pre-movement entity position
+		private double oldX;
+		private double oldY;
+		private double oldZ;
+		private double oldYSize;
+
+		private static PostMoveAction postMoveAction;
+	}
+
+	public enum PostMoveAction {
+		DO_NOTHING, SET_ON_GROUND_AND_COLLIDE, COLLIDE
+	}
+
+	private static ThreadLocal<EntityMoveInfo> entityMoveInfo = ThreadLocal.withInitial(EntityMoveInfo::new);
+
+	public static void preEntityMove(Entity entity, double dx, double dy, double dz) {
+		EntityMoveInfo info = entityMoveInfo.get();
+
+		if(info.isInsideEntityMove) {
+			throw new RuntimeException("Reentrance to Entity#moveEntity detected");
+		}
+
+		info.isInsideEntityMove = true;
+
 		// no clip? Then it's easy
 		if (entity.noClip) {
-			entity.moveEntity(dx, dy, dz);
+			info.postMoveAction = DO_NOTHING;
 			return;
 		}
-		
+
 		// save the pre-movement entity position
-		double oldX = entity.posX;
-		double oldY = entity.posY;
-		double oldZ = entity.posZ;
-		double oldYSize = entity.ySize;
-		
+		info.oldX = entity.posX;
+		info.oldY = entity.posY;
+		info.oldZ = entity.posZ;
+		info.oldYSize = entity.ySize;
+
 		// NOTE: crouching players on ships will not be moved by entity.moveEntity()
 		// because edge walk-over prevention doesn't know about ship blocks
 		// it always sees the player as already over the edge, so any movement is prevented
@@ -36,19 +64,34 @@ public class Collider {
 		if (isPlayerCrouching && isEntityOnAnyShip(entity)) {
 			// move the entity against the world without edge walk-over protections
 			entity.onGround = false;
-			entity.moveEntity(dx, dy, dz);
-			entity.onGround = true;
+			info.postMoveAction = SET_ON_GROUND_AND_COLLIDE;
 		} else {
 			// collide with the world normally
-			entity.moveEntity(dx, dy, dz);
-		}
-		
-		for (EntityShip ship : ShipLocator.getFromEntityLocation(entity)) {
-			// collide with the ships
-			ship.getCollider().onNearbyEntityMoved(oldX, oldY, oldZ, oldYSize, entity);
+			info.postMoveAction = COLLIDE;
 		}
 	}
-	
+
+	public static void postEntityMove(Entity entity, double dx, double dy, double dz) {
+		EntityMoveInfo info = entityMoveInfo.get();
+
+		if(!info.isInsideEntityMove) {
+			throw new RuntimeException("Reexitance from Entity#moveEntity detected");
+		}
+
+		if(info.postMoveAction == SET_ON_GROUND_AND_COLLIDE) {
+			entity.onGround = true;
+		}
+
+		if(info.postMoveAction != DO_NOTHING) {
+			for (EntityShip ship : ShipLocator.getFromEntityLocation(entity)) {
+				// collide with the ships
+				ship.getCollider().onNearbyEntityMoved(info.oldX, info.oldY, info.oldZ, info.oldYSize, entity);
+			}
+		}
+
+		info.isInsideEntityMove = false;
+	}
+
 	public static boolean isEntityOnShipLadder(EntityLivingBase entity) {
 		for (EntityShip ship : ShipLocator.getFromEntityLocation(entity)) {
 			if (ship.getCollider().isEntityOnLadder(entity)) {

--- a/src/main/java/cuchaz/ships/core/ShipIntermediary.java
+++ b/src/main/java/cuchaz/ships/core/ShipIntermediary.java
@@ -88,9 +88,14 @@ public class ShipIntermediary {
 		return translateDistance(world, player, x, y, z);
 	}
 	
-	public static void onEntityMove(Entity entity, double dx, double dy, double dz) {
+	public static void preEntityMove(Entity entity, double dx, double dy, double dz) {
 		// just forward to the collider
-		Collider.onEntityMove(entity, dx, dy, dz);
+		Collider.preEntityMove(entity, dx, dy, dz);
+	}
+
+	public static void postEntityMove(Entity entity, double dx, double dy, double dz) {
+		// just forward to the collider
+		Collider.postEntityMove(entity, dx, dy, dz);
 	}
 	
 	@SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
The mod has a transformer that replaces all regular method calls to `Entity#moveEntity` with a call to `ShipIntermediary#onEntityMove`, which in turn calls `Entity#moveEntity`. However, super method calls (`super.moveEntity()`) are not replaced. This is a problem because PlayerAPI adds some of those.

This PR solves the problem by reimplementing the hook using injection rather than redirection: instead of altering method calls, we insert a hook at the beginning and the end of `moveEntity`. (In Mixin terms, this is like an `@Inject` instead of a `@Redirect`.)

This fixes ship collision when Smart Moving is present. It doesn't fix the incompatibility entirely, since jumping doesn't work and crawling still makes you fall through, but these can be worked around on SM's side, which I have done in [my fork](https://github.com/makamys/SmartMoving).