### PR TITLE
Reduce verbosity of ship initialization and death messages

### DIFF
--- a/src/main/java/cuchaz/ships/EnhancedLogger.java
+++ b/src/main/java/cuchaz/ships/EnhancedLogger.java
@@ -54,4 +54,12 @@ public class EnhancedLogger {
 	public void info(Throwable t, String message, Object... args) {
 		log(Level.INFO, String.format(message, args), t);
 	}
+
+	public void debug(String message, Object... args) {
+		log(Level.DEBUG, String.format(message, args));
+	}
+
+	public void debug(Throwable t, String message, Object... args) {
+		log(Level.DEBUG, String.format(message, args), t);
+	}
 }

--- a/src/main/java/cuchaz/ships/EntityShip.java
+++ b/src/main/java/cuchaz/ships/EntityShip.java
@@ -151,7 +151,7 @@ public class EntityShip extends Entity {
 		m_collider.computeShipBoundingBox(boundingBox, posX, posY, posZ, rotationYaw);
 		
 		// LOGGING
-		Ships.logger.info(String.format("EntityShip %d initialized at (%.2f,%.2f,%.2f) + (%.4f,%.4f,%.4f)",
+		Ships.logger.debug(String.format("EntityShip %d initialized at (%.2f,%.2f,%.2f) + (%.4f,%.4f,%.4f)",
 			this.getEntityId(), posX, posY, posZ, motionX, motionY, motionZ
 		));
 	}
@@ -161,7 +161,7 @@ public class EntityShip extends Entity {
 		super.setDead();
 		
 		// LOGGING
-		Ships.logger.info("EntityShip %d died!", getEntityId());
+		Ships.logger.debug("EntityShip %d died!", getEntityId());
 		
 		// only restore blocks on the server
 		if (Environment.isServer()) {


### PR DESCRIPTION
This log message appears every time a ship gets loaded or unloaded, causing some log spam.